### PR TITLE
Secor to backup the data on configured dataset timezone

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -713,11 +713,11 @@ public class SecorConfig {
         String timezone = getString("secor.parser.timezone");
         return Strings.isNullOrEmpty(timezone) ? TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(timezone);
     }
-
     public TimeZone getMessageTimeZone() {
         String timezone = getString("secor.message.timezone");
         return Strings.isNullOrEmpty(timezone) ? TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(timezone);
     }
+    public String getFallbackDatasetTimeZone(){return getString("secor.dataset.fallback.timezone");}
 
     public boolean getBoolean(String name, boolean defaultValue) {
         return mProperties.getBoolean(name, defaultValue);

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -717,7 +717,7 @@ public class SecorConfig {
         String timezone = getString("secor.message.timezone");
         return Strings.isNullOrEmpty(timezone) ? TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(timezone);
     }
-    public String getFallbackDatasetTimeZone(){return getString("secor.dataset.fallback.timezone");}
+    public String getDefaultDatasetTimeZone(){return getString("secor.dataset.default.timezone");}
 
     public boolean getBoolean(String name, boolean defaultValue) {
         return mProperties.getBoolean(name, defaultValue);

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -859,4 +859,11 @@ public class SecorConfig {
     }
 
     public String[] getMessageChannelIdentifier() { return getStringArray("secor.partition.message.channel.identifier"); }
+
+    public String getDatasetTimeZoneKey() {
+        String defaultPath = "obsrv_meta.dataset_tz";
+        String timezoneKey = getString("secor.message.timezone.key");
+        return Strings.isNullOrEmpty(timezoneKey) ? defaultPath : timezoneKey;
+    }
+
 }

--- a/src/main/java/com/pinterest/secor/parser/ChannelDateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/ChannelDateMessageParser.java
@@ -60,7 +60,6 @@ public class ChannelDateMessageParser extends MessageParser {
 	private Map<String, String> partitionPrefixMap;
 	private static final String channelScrubRegex = "[^a-zA-Z0-9._$-]";
 	private SimpleDateFormat outputFormatter;
-	private final String defaultDatasetTimezone = "UTC";
 
 	public ChannelDateMessageParser(SecorConfig config) {
 		super(config);
@@ -104,7 +103,7 @@ public class ChannelDateMessageParser extends MessageParser {
 
 					String channel = getChannel(jsonObject);
 					String datasetTimeZone = this.getDatasetTz(jsonObject);
-					String timezone = Strings.isNullOrEmpty(datasetTimeZone) ? defaultDatasetTimezone : datasetTimeZone;
+					String timezone = Strings.isNullOrEmpty(datasetTimeZone) ? mConfig.getFallbackDatasetTimeZone() : datasetTimeZone;
 					LOG.info("Backup process configured timezone is " + timezone);
 					outputFormatter.setTimeZone(TimeZone.getTimeZone(timezone));
 					String path = channel + "/";
@@ -169,7 +168,7 @@ public class ChannelDateMessageParser extends MessageParser {
 			return JsonPath.parse(jsonObject).read("$." + mConfig.getDatasetTimeZoneKey(), String.class);
 		} catch (PathNotFoundException e) {
 			LOG.warn("Unable to get the tz path: " + e.getMessage());
-			return defaultDatasetTimezone;
+			return mConfig.getFallbackDatasetTimeZone();
 		}
 	}
 }

--- a/src/main/java/com/pinterest/secor/parser/ChannelDateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/ChannelDateMessageParser.java
@@ -103,7 +103,7 @@ public class ChannelDateMessageParser extends MessageParser {
 
 					String channel = getChannel(jsonObject);
 					String datasetTimeZone = this.getDatasetTz(jsonObject);
-					String timezone = Strings.isNullOrEmpty(datasetTimeZone) ? mConfig.getFallbackDatasetTimeZone() : datasetTimeZone;
+					String timezone = Strings.isNullOrEmpty(datasetTimeZone) ? mConfig.getDefaultDatasetTimeZone() : datasetTimeZone;
 					LOG.info("Backup process configured timezone is " + timezone);
 					outputFormatter.setTimeZone(TimeZone.getTimeZone(timezone));
 					String path = channel + "/";
@@ -168,7 +168,7 @@ public class ChannelDateMessageParser extends MessageParser {
 			return JsonPath.parse(jsonObject).read("$." + mConfig.getDatasetTimeZoneKey(), String.class);
 		} catch (PathNotFoundException e) {
 			LOG.warn("Unable to get the tz path: " + e.getMessage());
-			return mConfig.getFallbackDatasetTimeZone();
+			return mConfig.getDefaultDatasetTimeZone();
 		}
 	}
 }


### PR DESCRIPTION
This pull request includes updates for data to back up on the configured timezone at the process level and if the dataset is not configured with any timezone value then the dataset process will default to using the timezone value which is being provided during the installation.



Example of event - 

``` json


{
  "id": "batch01",
  "events": [],
  "obsrv_meta": {
    "syncts": 1701755706325,
    "dataset_tz": "UTC"
  },
  "dataset": "telemetry-data",
  "mid": "d7347050-9332-11ee-95e6-cbcd067c4c16",
  "syncts": 1701755706325
}

```

The process finds for the `secor.message.timezone.key`, which can be configured to read from `obsrv_meta.dataset_tz` at process level/dataset level  and then sets the time zone for the backup timestamp."