### PR TITLE
build: migrate Docker base image to Docker Hardened Images (DHI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: dhi.io
-        username: ${{ vars.DOCKERHUB_USERNAME }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build Docker Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,15 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        
+
+    - name: Log in to dhi.io (Docker Hardened Images)
+      if: success()
+      uses: docker/login-action@v3
+      with:
+        registry: dhi.io
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Build Docker Image
       if: success()
       run: mvn clean install -DskipTests -Pbuild-docker-image -Ddockerfile.repository=${{ env.DOCKER_IMAGE_NAME }} -Ddockerfile.tag=${{ env.DOCKER_IMAGE_TAG }} --file pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 # FROM --platform=linux/amd64,linux/arm64 eclipse-temurin:11.0.20.1_1-jdk-focal
 ARG TARGETPLATFORM
-FROM eclipse-temurin:11.0.20.1_1-jdk-focal as base
-# https://github.com/docker-library/openjdk/issues/145#issuecomment-334561903
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894979
-RUN rm /etc/ssl/certs/java/cacerts ; update-ca-certificates -f
+# Docker Hardened Image (near-zero-CVE). JRE (not JDK) is enough at runtime; the
+# -dev variant retains the shell needed by docker-entrypoint.sh and the build steps.
+FROM dhi.io/eclipse-temurin:11-jre-dev as base
+# DHI images default to a non-root user; the build needs root to create the secor
+# user and set ownership (the upstream temurin image ran as root).
+USER root
 
 RUN mkdir -p /opt/secor
 
@@ -11,8 +13,10 @@ RUN mkdir -p /opt/secor
 ENV SECOR_HOME=/opt/secor
 WORKDIR $SECOR_HOME
 
-RUN groupadd --system --gid=9999 secor && \
-    useradd --system --home-dir $SECOR_HOME --uid=9999 --gid=secor secor
+# The hardened base has no shadow utils (groupadd/useradd); create the system
+# user directly in /etc/passwd + /etc/group.
+RUN echo 'secor:x:9999:' >> /etc/group && \
+    echo 'secor:x:9999:9999::/opt/secor:/usr/sbin/nologin' >> /etc/passwd
 
 ADD target/secor-*-bin.tar.gz $SECOR_HOME
 


### PR DESCRIPTION
## Summary
Migrate the Docker base image to **Docker Hardened Images (DHI)** (`dhi.io`), per `DHI-MIGRATION-PLAN.md`. Part of a phased, per-repo rollout.

- `eclipse-temurin:11.0.20.1_1-jdk-focal` → `dhi.io/eclipse-temurin:11-jre-dev` (near-zero-CVE base).
- **JRE instead of JDK** at runtime → smaller image, lower CVE surface. The `-dev` variant retains the shell required by `docker-entrypoint.sh`.
- **Removed** the `rm /etc/ssl/certs/java/cacerts; update-ca-certificates -f` hack — a focal/temurin cacerts workaround that doesn't apply to DHI (and `update-ca-certificates` isn't present on the hardened base).
- The hardened base has **no shadow utils** (`groupadd`/`useradd`), so the `secor` system user (uid 9999) is created directly in `/etc/passwd` + `/etc/group`.
- `USER root` for the build steps (DHI defaults non-root); the final image still runs as the non-root **`secor`** user (uid 9999), as before.

## Verification (local)
The image is built by Maven (`-Pbuild-docker-image`), so the real `target/secor-*-bin.tar.gz` isn't available outside a Maven build. I validated the **Dockerfile mechanics** with a synthetic tarball (`--platform=linux/amd64`):
- ✅ Builds green; `groupadd`-free user creation works.
- ✅ `java -version` → OpenJDK 11.0.26 (JRE).
- ✅ Runs as `uid=9999(secor)`; `/docker-entrypoint.sh` owned `secor:secor`, mode `755`.

## Notes for reviewers
- **Full image build happens via Maven in CI** — please confirm the CI run is green with the real secor binary. CI also needs **`dhi.io` pull access** (the `FROM` resolves at build).
- The DHI `eclipse-temurin:11-jre-dev` image is **amd64-only** (no arm64 manifest) — fine for the amd64 deploy target; build with `--platform=linux/amd64` if building on arm64.
- ⚠️ Removed the cacerts workaround — secor uses TLS (Kafka/S3); DHI temurin ships standard CA certs, but please confirm TLS connectivity in a test deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)